### PR TITLE
Adjust the YieldFixUp function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "haproxy-api"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Aleksandr Orlenko <zxteam@pm.me>"]
 edition = "2021"
 repository = "https://github.com/khvzak/haproxy-api-rs"


### PR DESCRIPTION
Adjust the YieldFixUp function to yield using `core.msleep(1)` after the initial `core.yield()`. 
`msleep` is a yielding function, in this case with a 1ms sleep.
The reason for switching over to msleep is because purely utilizing `core.yield()` can cause very fast polling of the async lua function future.