### PR TITLE
Update examples to haproxy 3.2 and add prometheus example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ features = ["lua54"]
 members = [
     "examples/async_serve_file",
     "examples/brotli",
+    "examples/prometheus",
     "examples/simple",
 ]
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Please check the [async_serve_file](examples/async_serve_file) example to see ho
 Please check our [examples](examples):
 * [async serve file](examples/async_serve_file) - How to serve files asynchronously
 * [brotli](examples/brotli) - How to add brotli compression to HAProxy using filters API
+* [prometheus](examples/prometheus) - How to serve prometheus metrics from HAProxy after observing query params `foo` and `bar` in the backend queries
 * [simple](examples/simple) - How to register fetches and converters
 
 ## Restrictions

--- a/examples/async_serve_file/Dockerfile
+++ b/examples/async_serve_file/Dockerfile
@@ -1,14 +1,20 @@
-FROM ubuntu:mantic
+FROM ubuntu:noble
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y --no-install-recommends rust-all git haproxy ca-certificates
+    apt install -y --no-install-recommends software-properties-common
+
+RUN add-apt-repository ppa:vbernat/haproxy-3.2 -y
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt install -y --no-install-recommends curl git haproxy ca-certificates build-essential libclang-dev
 
 COPY . /root/haproxy
 WORKDIR /root/haproxy
 
 # Build plugin
-RUN sed -rie 's/^(haproxy-api)\s=\s.+$/\1 = "*"/g' Cargo.toml \
-    && cargo build --release
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+    . "$HOME/.cargo/env" && \
+    sed -rie 's/^(haproxy-api)\s=\s.+$/\1 = "*"/g' Cargo.toml && \
+    cargo build --release
 
 CMD ["haproxy", "-d", "-f", "haproxy.cfg"]

--- a/examples/async_serve_file/docker-compose.yml
+++ b/examples/async_serve_file/docker-compose.yml
@@ -1,0 +1,5 @@
+---
+services:
+  lua-async-serve-file:
+    build: .
+    network_mode: host

--- a/examples/async_serve_file/docker-compose.yml
+++ b/examples/async_serve_file/docker-compose.yml
@@ -2,4 +2,5 @@
 services:
   lua-async-serve-file:
     build: .
-    network_mode: host
+    ports:
+      - 8080:8080

--- a/examples/brotli/Dockerfile
+++ b/examples/brotli/Dockerfile
@@ -1,14 +1,20 @@
-FROM ubuntu:mantic
+FROM ubuntu:noble
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y --no-install-recommends rust-all git haproxy ca-certificates
+    apt install -y --no-install-recommends software-properties-common
+
+RUN add-apt-repository ppa:vbernat/haproxy-3.2 -y
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt install -y --no-install-recommends curl git haproxy ca-certificates build-essential libclang-dev
 
 COPY . /root/haproxy
 WORKDIR /root/haproxy
 
 # Build plugin
-RUN sed -rie 's/^(haproxy-api)\s=\s.+$/\1 = "*"/g' Cargo.toml \
-    && cargo build --release
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+    . "$HOME/.cargo/env" && \
+    sed -rie 's/^(haproxy-api)\s=\s.+$/\1 = "*"/g' Cargo.toml && \
+    cargo build --release
 
 CMD ["haproxy", "-d", "-f", "haproxy.cfg"]

--- a/examples/brotli/docker-compose.yml
+++ b/examples/brotli/docker-compose.yml
@@ -2,4 +2,5 @@
 services:
   lua-brotli:
     build: .
-    network_mode: host
+    ports:
+      - 8080:8080

--- a/examples/brotli/docker-compose.yml
+++ b/examples/brotli/docker-compose.yml
@@ -1,0 +1,5 @@
+---
+services:
+  lua-brotli:
+    build: .
+    network_mode: host

--- a/examples/prometheus/.cargo/config.toml
+++ b/examples/prometheus/.cargo/config.toml
@@ -1,0 +1,11 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]

--- a/examples/prometheus/Cargo.toml
+++ b/examples/prometheus/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "haproxy_prometheus_module"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+form_urlencoded = { version = "1.2.2", features = [
+    "alloc",
+], default-features = false }
+haproxy-api = { path = "../.." }
+mlua = { version = "0.11", features = ["macros"] }
+prometheus = { version = "0.14.0", default-features = false }

--- a/examples/prometheus/Dockerfile
+++ b/examples/prometheus/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:noble
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt install -y --no-install-recommends software-properties-common
+
+RUN add-apt-repository ppa:vbernat/haproxy-3.2 -y
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt install -y --no-install-recommends curl git haproxy ca-certificates build-essential libclang-dev
+
+COPY . /root/haproxy
+WORKDIR /root/haproxy
+
+# Build plugin
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+    . "$HOME/.cargo/env" && \
+    sed -rie 's/^(haproxy-api)\s=\s.+$/\1 = "*"/g' Cargo.toml && \
+    cargo build --release
+
+CMD ["haproxy", "-d", "-f", "haproxy.cfg"]

--- a/examples/prometheus/docker-compose.yml
+++ b/examples/prometheus/docker-compose.yml
@@ -1,0 +1,16 @@
+---
+services:
+  lua-prometheus:
+    build: .
+    ports:
+      - 8080:8080
+      - 9000:9000
+
+  http-listener:
+    image: mendhak/http-https-echo:38
+    environment:
+        - HTTP_PORT=8888
+        - HTTPS_PORT=9999
+    ports:
+        - "8888:8888"
+        - "9999:9999"

--- a/examples/prometheus/haproxy.cfg
+++ b/examples/prometheus/haproxy.cfg
@@ -1,0 +1,31 @@
+global
+    master-worker
+    tune.lua.bool-sample-conversion normal
+    # MacOS
+    lua-prepend-path "../../target/debug/lib?.dylib" cpath
+    lua-prepend-path "target/release/lib?.so" cpath
+    lua-load haproxy.lua
+    ssl-server-verify none
+
+defaults
+    mode http
+    option httplog
+    log stdout format raw daemon info
+    timeout connect 1s
+    timeout client 3s
+    timeout server 3s
+
+frontend http-in
+    bind *:8080
+    default_backend servers
+
+backend servers
+    http-request set-header X-Request-URI %[capture.req.uri] # needed to capture req_uri, not possible through code hooks
+    http-request add-header X-Set-Response-Delay-Ms 500 # add delay to response
+    http-request lua.rust_req
+    server default http-listener:8888
+    http-after-response lua.rust_resp
+
+listen metrics
+    bind *:9000
+    http-request use-service lua.serve_metrics

--- a/examples/prometheus/haproxy.lua
+++ b/examples/prometheus/haproxy.lua
@@ -1,0 +1,1 @@
+require("haproxy_prometheus_module")

--- a/examples/prometheus/src/lib.rs
+++ b/examples/prometheus/src/lib.rs
@@ -1,0 +1,180 @@
+use haproxy_api::{Action, Core, ServiceMode, Txn};
+use mlua::prelude::*;
+use prometheus::{
+    register_counter_vec_with_registry, register_histogram_vec_with_registry,
+    register_int_gauge_vec_with_registry, Registry, TextEncoder,
+};
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    ops::Sub,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+pub const DEFAULT_HISTOGRAM_BUCKETS_SECONDS: [f64; 9] =
+    [0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0];
+
+#[mlua::lua_module(skip_memory_check)]
+fn haproxy_prometheus_module(lua: &Lua) -> LuaResult<bool> {
+    let core = Core::new(lua)?;
+    let registry = init_registry()?;
+
+    let foo_call_total = register_counter_vec_with_registry!(
+        "foo_http_requests_total",
+        "Number of HTTP requests made with foo query param.",
+        &["param"],
+        registry
+    )
+    .map_err(|e| e.into_lua_err())?;
+
+    let bar_call_total = register_counter_vec_with_registry!(
+        "bar_http_requests_total",
+        "Number of HTTP requests made with bar query param.",
+        &["param"],
+        registry
+    )
+    .map_err(|e| e.into_lua_err())?;
+
+    let response_time = register_histogram_vec_with_registry!(
+        "total_response_time_seconds",
+        "Response time.",
+        &["foo", "bar"],
+        registry
+    )
+    .map_err(|e| e.into_lua_err())?;
+
+    // process request items only available in this hook
+    // and save them in txn vars if needed
+    core.register_action("rust_req", &[Action::HttpReq], 0, |_lua, txn: Txn| {
+        println!("rust_req BEGIN");
+
+        for kv in txn.http()?.req_get_headers()?.pairs() {
+            let (k, v): (String, Vec<String>) = kv?;
+            println!("request header {k}: {v:?}");
+        }
+
+        // get x-request-uri set by previous
+        // haproxy set-header capture directive
+        let req_uri = txn
+            .http()?
+            .req_get_headers()?
+            .get_first::<String>("x-request-uri")?
+            .unwrap_or_default();
+        let req_uri = req_uri.strip_prefix("/?").unwrap_or(&req_uri);
+
+        println!("req_uri: {req_uri:?}");
+        txn.set_var("txn.req_uri", req_uri)?;
+
+        let start_time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| e.into_lua_err())?
+            .as_millis();
+
+        println!("start_time: {start_time:?}");
+        txn.set_var("txn.start_time", start_time)?;
+
+        println!("rust_req END");
+        Ok(())
+    })?;
+
+    // process response items only available in this hook
+    // plus saved txn vars and update prometheus metrics
+    core.register_action(
+        "rust_resp",
+        &[Action::HttpAfterRes],
+        0,
+        move |_lua, txn: Txn| {
+            println!("rust_resp BEGIN");
+
+            for kv in txn.http()?.res_get_headers()?.pairs() {
+                let (k, v): (String, Vec<String>) = kv?;
+                println!("response header {k}: {v:?}");
+            }
+
+            let req_uri = txn.get_var::<String>("txn.req_uri")?;
+            let query_params: HashMap<Cow<'_, str>, Cow<'_, str>> =
+                form_urlencoded::parse(req_uri.as_bytes()).collect();
+            println!("query_params: {query_params:?}");
+
+            let foo_param = query_params.get("foo");
+            if let Some(param) = foo_param {
+                foo_call_total.with_label_values(&[param]).inc();
+            }
+
+            let bar_param = query_params.get("bar");
+            if let Some(param) = bar_param {
+                bar_call_total.with_label_values(&[param]).inc();
+            }
+
+            // Tt and others are not available
+            let method = txn.f.get::<String>("method", ())?;
+            println!("method {method:?}");
+            let status = txn.f.get::<String>("status", ())?;
+            println!("status {status:?}");
+
+            let start_time = txn
+                .get_var::<u128>("txn.start_time")
+                .map(|e| Duration::from_millis(e as u64))?;
+
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_err(|e| e.into_lua_err())?;
+
+            let process_time = now.sub(start_time);
+            println!("computed Tt {process_time:?}");
+
+            let foo_value = foo_param.cloned().unwrap_or_default();
+            let bar_value = bar_param.cloned().unwrap_or_default();
+
+            response_time
+                .with_label_values(&[foo_value, bar_value])
+                .observe(process_time.as_secs_f64());
+
+            println!("rust_resp END");
+            Ok(())
+        },
+    )?;
+
+    let get_metrics = LuaFunction::wrap(move || render_metrics(&registry));
+
+    let code = mlua::chunk! {
+        local applet = ...
+        local response, err = $get_metrics()
+
+        applet:set_status(200)
+        applet:add_header("content-length", string.len(response))
+        applet:add_header("content-type", "application/octet-stream")
+        applet:start_response()
+        applet:send(response)
+    };
+    core.register_lua_service("serve_metrics", ServiceMode::Http, code)?;
+
+    Ok(true)
+}
+
+fn init_registry() -> LuaResult<Registry> {
+    let registry = prometheus::Registry::new();
+
+    let constant_gauge = register_int_gauge_vec_with_registry!(
+        "app_name",
+        "Metric with a constant '1' value labeled with app name",
+        &["app",],
+        registry,
+    )
+    .map_err(|e| e.into_lua_err())?;
+
+    constant_gauge
+        .with_label_values(&["haproxy_prometheus_module"])
+        .set(1);
+
+    Ok(registry)
+}
+
+fn render_metrics(registry: &Registry) -> LuaResult<String> {
+    let mut output: String = String::new();
+    TextEncoder::new()
+        .encode_utf8(&registry.gather(), &mut output)
+        .map_err(|e| e.into_lua_err())?;
+
+    Ok(output)
+}

--- a/examples/simple/Dockerfile
+++ b/examples/simple/Dockerfile
@@ -1,14 +1,20 @@
-FROM ubuntu:mantic
+FROM ubuntu:noble
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y --no-install-recommends rust-all git haproxy ca-certificates
+    apt install -y --no-install-recommends software-properties-common
+
+RUN add-apt-repository ppa:vbernat/haproxy-3.2 -y
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt install -y --no-install-recommends curl git haproxy ca-certificates build-essential libclang-dev
 
 COPY . /root/haproxy
 WORKDIR /root/haproxy
 
 # Build plugin
-RUN sed -rie 's/^(haproxy-api)\s=\s.+$/\1 = "*"/g' Cargo.toml \
-    && cargo build --release
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+    . "$HOME/.cargo/env" && \
+    sed -rie 's/^(haproxy-api)\s=\s.+$/\1 = "*"/g' Cargo.toml && \
+    cargo build --release
 
 CMD ["haproxy", "-d", "-f", "haproxy.cfg"]

--- a/examples/simple/docker-compose.yml
+++ b/examples/simple/docker-compose.yml
@@ -1,0 +1,5 @@
+---
+services:
+  lua-simple:
+    build: .
+    network_mode: host

--- a/examples/simple/docker-compose.yml
+++ b/examples/simple/docker-compose.yml
@@ -2,4 +2,5 @@
 services:
   lua-simple:
     build: .
-    network_mode: host
+    ports:
+      - 8080:8080

--- a/examples/simple/haproxy.cfg
+++ b/examples/simple/haproxy.cfg
@@ -15,7 +15,7 @@ defaults
     timeout server 3s
 
 listen http-in
-    bind 127.0.0.1:8080
+    bind *:8080
     # rust_fetch gets x-bot header, rust_conv reverse it, and then we compare it with "bot"
     http-request deny if { lua.rust_fetch(x-bot),lua.rust_conv -m str bot }
     http-request lua.rust_act


### PR DESCRIPTION
- Update examples to use haproxy 3.2
- Update docker image and haproxy distribution to align with these versions
- Add a prometheus metrics server example